### PR TITLE
Fixing documents extraction from raw lunr json

### DIFF
--- a/bin/lunr-index-build
+++ b/bin/lunr-index-build
@@ -42,7 +42,7 @@ process.stdin.on('data', function (chunk) {
 
 process.stdin.on('end', function () {
   try {
-    var documents = JSON.parse(inputBuffer)
+    var documents = JSON.parse(inputBuffer).entries
   } catch (e) {
     console.error('invalid input JSON')
     process.exit(1)


### PR DESCRIPTION
It's now contained in the `entries` field
